### PR TITLE
:sparkles: Feature: adds 'uploadfiles' flag, cleanfiles' flag, and 'fileformat' options, as well as including metadata

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,11 @@ ENV PYTHONUNBUFFERED=1
 # by default the script will use 5, which means that the script will rerun every 5 minutes
 # users can overrule the default by simply providing their own INTERVAL variable
 ENV INTERVAL=5
-
+# default format for saving files to, supports yt_dlp formatting
+ENV FILEFORMAT="%(playlist)s/%(title)s-%(id)s.%(ext)s"
+# default to true to upload files, can be overridden by users
+ENV UPLOADFILES=true
+# default to true to clean files, can be overridden by users
+ENV CLEANFILES=true
 # run the Music Service with Python
 CMD [ "python", "./main.py"]

--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ docker run -d \
 thijstakken/musicservice:latest
 ```
 
+> :information_source: **Optional**: Three additional env flags are available:
+> `-e UPLOADFILES=false` can be set to not upload files to DAV
+> `-e CLEANFILES=false` can be set to not clean up music cache
+> `-e FILEFORMAT="%(playlist)s/%(title)s-%(id)s.%(ext)s"` can be set to change the file name format
+
 Before you can run the docker-compose or docker run command, you will first have to make a few changes.
 
 <br>


### PR DESCRIPTION
Thanks for your great work! This has worked awesome, but many of my files weren't able to pick up metadata from various sources, so I wanted to add the metadata directly from the source.  Metadata now looks about 90% complete, with at least enough to make minor changes. (Test on just under 500 files, all from Soundcloud though.

I also like to hoard data, so I wanted to be able to keep the files in the original volume/storage location, so added a flag for that.

Just looking, figured it would be easy enough to allow only downloading to local and not uploading using a similar flag!

I'm not **exceedingly** familiar with Python anymore, but I was having weirdness with typecasting from string to bool for the flags, hence doing a string check on them!